### PR TITLE
Only supersede requests from the package belonging to this PR

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -903,7 +903,7 @@ aiohttp = "^3.8.4"
 type = "git"
 url = "https://github.com/dcermak/py-obs.git"
 reference = "main"
-resolved_reference = "ea84247dd3d8b8074d669697c4d216399177ae0c"
+resolved_reference = "f22027a2dbeae1e854c1e8d412749fce74cab042"
 
 [[package]]
 name = "pydantic"


### PR DESCRIPTION
Currently the bot would supersede requests from all currently opened PRs when any of the PRs gets closed or updated. That is undesirable, it should only do that for SRs belonging to the current PR. Fortunately we can achieve that easily, as we create a separate project for each PR.