### PR TITLE
Fix typos in the user guide

### DIFF
--- a/scm_staging/webhook.py
+++ b/scm_staging/webhook.py
@@ -521,7 +521,7 @@ def main():
     LOGGER.info(f"app listent to port {options.port}")
     shutdown_event = asyncio.Event()
 
-    mq.create_db(options.db_file)
+    create_db(options.db_file)
     LOGGER.info("Database opened")
     mqp = Process(target=mq.rabbit_listener, args=(options.db_file,))
     mqp.start()

--- a/source/user_guide.rst
+++ b/source/user_guide.rst
@@ -65,7 +65,7 @@ devel project as follows:
 Contributor Guide
 -----------------
 
-1. Install the ``git-scm-bridge``.
+1. Install the ``obs-scm-bridge``.
 
 2. Checkout the devel project of the package that you want to contribute to:
 
@@ -82,7 +82,7 @@ Contributor Guide
 
 .. code-block:: shell-session
 
-   git remote add fork gitea@src.opensuse.org/$username/$pkg_name
+   git remote add fork gitea@src.opensuse.org:$username/$pkg_name
    git fetch fork
 
 5. Implement your changes:


### PR DESCRIPTION
git-scm-bridge -> obs-scm-bridge, / -> : in ssh git url